### PR TITLE
catch regex exception instead of failing entirely

### DIFF
--- a/src/parsers/client/browser.ts
+++ b/src/parsers/client/browser.ts
@@ -95,7 +95,13 @@ export default class BrowserParser {
 
     if (!result.engine) {
       for (const browserEngine of browserEngines) {
-        const match = RegExp(browserEngine.regex, "i").exec(userAgent);
+
+        let match = null;
+        try {
+          match = RegExp(browserEngine.regex, "i").exec(userAgent);
+        } catch {
+          // TODO: find out why it fails in some browsers
+        }
 
         if (!match) continue;
 


### PR DESCRIPTION
This PR handles the exception as a phenomenon.
On the other hand it would be nice to trace down suspicious regexps to have a better understanding of what is going on under the hood in case of an error.