### PR TITLE
Add union type `DeviceType` for more concrete `device.type` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "device-detector-js",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "A javascript port of Matomo device-detector",
   "homepage": "https://github.com/etienne-martin/device-detector-js",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import BrowserParser from "./parsers/client/browser";
 import BotParser = require("./parsers/bot");
 import { userAgentParser } from "./utils/user-agent";
 import { versionCompare } from "./utils/version-compare";
+import { GenericDeviceResult } from "./typings/device";
 
 namespace DeviceDetector {
   export interface DeviceDetectorResult {
@@ -147,8 +148,8 @@ class DeviceDetector {
     /**
      * All detected feature phones running android are more likely smartphones
      */
-    if (result.device && result.device?.type === "feature phone" && osFamily === "Android") {
-      result.device.type = "smartphone";
+    if ((result.device?.type as string) === "feature phone" && osFamily === "Android") {
+      result.device!.type = "smartphone";
     }
 
     /**
@@ -243,7 +244,7 @@ class DeviceDetector {
     return userAgentParser("Touch", userAgent);
   };
 
-  private createDeviceObject = () => ({
+  private createDeviceObject = (): GenericDeviceResult => ({
     type: "",
     brand: "",
     model: ""

--- a/src/parsers/device/cameras.ts
+++ b/src/parsers/device/cameras.ts
@@ -19,9 +19,9 @@ export default class CameraParser {
       result.type = "camera";
       result.brand = brand;
 
-      if (camera.model) {
+      if ("model" in camera && camera.model) {
         result.model = variableReplacement(camera.model, match).trim();
-      } else if (camera.models) {
+      } else if ("models" in camera && camera.models) {
         for (const model of camera.models) {
           const modelMatch = userAgentParser(model.regex, userAgent);
 

--- a/src/parsers/device/consoles.ts
+++ b/src/parsers/device/consoles.ts
@@ -1,5 +1,5 @@
 import consoles from "../../fixtures/regexes/device/consoles.json";
-import { GenericDeviceResult } from "../../typings/device";
+import { DeviceType, GenericDeviceResult } from "../../typings/device";
 import { variableReplacement } from "../../utils/variable-replacement";
 import { userAgentParser } from "../../utils/user-agent";
 
@@ -16,12 +16,12 @@ export default class ConsoleParser {
 
       if (!match) continue;
 
-      result.type = gameConsole.device;
+      result.type = gameConsole.device as DeviceType;
       result.brand = brand;
 
-      if (gameConsole.model) {
+      if ("model" in gameConsole && gameConsole.model) {
         result.model = variableReplacement(gameConsole.model, match).trim();
-      } else if (gameConsole.models) {
+      } else if ("models" in gameConsole && gameConsole.models) {
         for (const model of gameConsole.models) {
           const modelMatch = userAgentParser(model.regex, userAgent);
 

--- a/src/parsers/device/portable-media-players.ts
+++ b/src/parsers/device/portable-media-players.ts
@@ -1,5 +1,5 @@
 import portableMediaPlayers from "../../fixtures/regexes/device/portable_media_player.json";
-import { GenericDeviceResult } from "../../typings/device";
+import { DeviceType, GenericDeviceResult } from "../../typings/device";
 import { variableReplacement } from "../../utils/variable-replacement";
 import { userAgentParser } from "../../utils/user-agent";
 
@@ -16,12 +16,12 @@ export default class PortableMediaPlayersParser {
 
       if (!match) continue;
 
-      result.type = portableMediaPlayer.device;
+      result.type = portableMediaPlayer.device as DeviceType;
       result.brand = brand;
 
-      if (portableMediaPlayer.model) {
+      if ("model" in portableMediaPlayer && portableMediaPlayer.model) {
         result.model = variableReplacement(portableMediaPlayer.model, match).trim();
-      } else if (portableMediaPlayer.models) {
+      } else if ("models" in portableMediaPlayer && portableMediaPlayer.models) {
         for (const model of portableMediaPlayer.models) {
           const modelMatch = userAgentParser(model.regex, userAgent);
 

--- a/src/parsers/device/televisions.ts
+++ b/src/parsers/device/televisions.ts
@@ -23,9 +23,9 @@ export default class TelevisionParser {
 
       result.brand = brand;
 
-      if (television.model) {
+      if ("model" in television && television.model) {
         result.model = buildModel(variableReplacement(television.model, match)).trim();
-      } else if (television.models) {
+      } else if ("models" in television && television.models) {
         for (const model of television.models) {
           const modelMatch = userAgentParser(model.regex, userAgent);
 

--- a/src/typings/device.ts
+++ b/src/typings/device.ts
@@ -1,5 +1,17 @@
+export type DeviceType =
+  | ""
+  | "desktop"
+  | "smartphone"
+  | "tablet"
+  | "television"
+  | "smart display"
+  | "camera"
+  | "car"
+  | "console"
+  | "portable media player"
+
 export interface GenericDeviceResult {
-  type: string;
+  type: DeviceType;
   brand: string;
   model: string;
 }


### PR DESCRIPTION
1) Add union type `DeviceType` for more concrete `device.type` usage (when `device` is `GenericDeviceResult`).
2) Fix common TS problems.

### Motivation 
I use this package for Next.js projects (with TS), and not clear how match device type. 
With union-typed `.device.type` it's so easy to enforce conditions and other device-matching code.